### PR TITLE
Confirmation page created and edit address page modified.

### DIFF
--- a/app/services/addressLookup.scala
+++ b/app/services/addressLookup.scala
@@ -70,4 +70,8 @@ case class Address(uprn: String, lines: Array[String], town: String, postcode: S
     val lineStr = lines.mkString(" ")
     s"$lineStr $town $postcode"
   }
+
+  def line0 = if(lines.length < 1) "" else lines(0)
+  def line1 = if(lines.length < 2) "" else lines(1)
+  def line2 = if(lines.length < 3) "" else lines(2)
 }

--- a/app/views/addresslookup/address_lookup.scala.html
+++ b/app/views/addresslookup/address_lookup.scala.html
@@ -1,4 +1,4 @@
-@(typedDetails: AddressTypedDetails, countries: List[String], addressList: Option[List[services.Address]], errorMessage: Option[List[AddressErrorMsg]] = None)(implicit request: Request[_])
+@(typedDetails: AddressTypedDetails, address:Option[services.Address], countries: List[String], addressList: Option[List[services.Address]], errorMessage: Option[List[AddressErrorMsg]] = None)(implicit request: Request[_])
 
 <script src="assets/javascripts/vendor/jquery-1.11.0.min.js"></script>
 <script src="assets/javascripts/selection-buttons.js"></script>
@@ -41,7 +41,7 @@
         </div>
 
         <div class="panel panel-border-narrow" id="example-UK">
-            @ukTab(typedDetails, addressList, errorMessage)
+            @ukTab(typedDetails, addressList, address, errorMessage)
         </div>
 
         <div class="panel panel-border-narrow" id="example-INT" style="display: none;">

--- a/app/views/addresslookup/confirmationPage.scala.html
+++ b/app/views/addresslookup/confirmationPage.scala.html
@@ -1,0 +1,52 @@
+@(typedDetails: AddressTypedDetails, address:Option[services.Address], noFixedAddress:Boolean)(implicit request: Request[_])
+
+<script src="assets/javascripts/vendor/jquery-1.11.0.min.js"></script>
+<script src="assets/javascripts/selection-buttons.js"></script>
+<script src="assets/javascripts/redirect.js"></script>
+<script src="assets/javascripts/application.js"></script>
+
+<style>
+    .govuk-box-highlight {
+    margin: 1em 0 1em 0;
+    padding: 2em 0 1em 0;
+    color: #fff;
+    background: #28a197;
+    text-align: center;
+    background: #28a197;
+    }
+
+    .govuk-box-highlight h2{
+    color: #fff;
+    }
+</style>
+
+<div class="phase-banner-alpha">
+    <p>
+        <strong class="phase-tag">ALPHA</strong>
+        <span>This is a new service – your <a href="#">feedback</a> will help us to improve it.</span>
+    </p>
+</div>
+
+@main_template(title = "Address lookup demo", bodyClasses = None) {
+
+    <div class="govuk-box-highlight">
+        <h2 class="bold-large">Application complete</h2>
+        <p>Address:</p>
+        <span>
+            @if(noFixedAddress) {
+                No fixed address.
+            } else {
+            @if( address.nonEmpty) {
+                @for( line <- address.get.lines) {
+                    <p>@line</p>
+                }
+                <p>@address.get.town</p>
+                <p>@address.get.postcode</p>
+            } else {
+            ERROR: Unable to find address details
+            }
+        }
+        </span>
+    </div>
+
+}

--- a/app/views/addresslookup/ukTab.scala.html
+++ b/app/views/addresslookup/ukTab.scala.html
@@ -1,10 +1,11 @@
-@(typedDetails: AddressTypedDetails, addressList: Option[List[services.Address]], errorMessage: Option[List[AddressErrorMsg]], maxAddresses: Int = 50)(implicit request: Request[_])
+@(typedDetails: AddressTypedDetails, addressList: Option[List[services.Address]], address:Option[services.Address], errorMessage: Option[List[AddressErrorMsg]], maxAddresses: Int = 50)(implicit request: Request[_])
 
 <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7/jquery.js"></script>
 <script src="http://malsup.github.com/jquery.form.js"></script>
 
 <script>
         $(document).ready(function() {
+        $("#myForm").find("#hiddenselection").prop('checked', false);
             $('#editAddress').click(function(){
                 $("#myForm").find("#hiddenselection").prop('checked', true);
                 $("#myForm").submit();
@@ -72,7 +73,7 @@
 
 
         @for( addrX <- addressList) {
-            @if(addrX.length <= maxAddresses) {
+            @if(addrX.length <= maxAddresses && !errorMessage.exists( f => f.contains(NoMatchesFound() ))) {
                 <div class="form-group">
                     <label class="form-label-bold" for="Address-table">Found addresses</label>
                     <table id="Address-table">
@@ -81,7 +82,9 @@
                             <tr>
                                 <td class="selection"><input id='@{
                                     addr.uprn
-                                }' type="radio" name="radio-inline-group" value="Address-selection">
+                                }' type="radio" name="radio-inline-group" value='@{
+                                    addr.uprn
+                                }'>
                                 </td>
                                 <td><label for='@{
                                     addr.uprn
@@ -98,24 +101,27 @@
         }
 
         @if(errorMessage.exists( f => f.contains(AddManualEntry() ))) {
-            <div class="form-group">
-                <h2>Amend address</h2>
-                <label class="form-label" for="UK-address-line1">Address line 1</label>
-                <input class="form-control" id="UK-address-line1" name="UK-postcode" type="text" maxlength="8" value='@{typedDetails.line1}'>
-                <label class="form-label" for="UK-address-line2">Address line 2</label>
-                <input class="form-control" id="UK-address-line2" name="UK-postcode" type="text" maxlength="8" value='@{typedDetails.line2}'>
-                <label class="form-label" for="UK-address-town">Nearest town or city</label>
-                <input class="form-control" id="UK-address-town" name="UK-postcode" type="text" maxlength="8" value='@{typedDetails.town}'>
-                <label class="form-label" for="UK-address-county">County</label>
-                <input class="form-control" id="UK-address-county" name="UK-postcode" type="text" maxlength="8" value='@{typedDetails.county}'>
-            </div>
-
+            @if( address.nonEmpty) {
+                <div class="form-group">
+                    <h2>Amend address</h2>
+                    <label class="form-label" for='UK-address-line1'>Address line 1</label>
+                    <input class="form-control" id='UK-address-line1' name="UK-address-line1" type="text" value='@{address.get.line0}'>
+                    <label class="form-label" for='UK-address-line2'>Address line 2</label>
+                    <input class="form-control" id='UK-address-line2' name="UK-address-line2" type="text" value='@{address.get.line1}'>
+                    <label class="form-label" for='UK-address-line3'>Address line 3</label>
+                    <input class="form-control" id='UK-address-line3' name="UK-address-line3" type="text" value='@{address.get.line2}'>
+                    <label class="form-label" for="UK-address-town">Nearest town or city</label>
+                    <input class="form-control" id="UK-address-town" name="UK-town" type="text" value='@address.get.town'>
+                    <label class="form-label" for="UK-address-county">County</label>
+                    <input class="form-control" id="UK-address-county" name="UK-county" type="text">
+                </div>
+            }
         }
 
-    <div class="form-group">
-        <input class="button" type="submit"  value="Find address">
-        or <a href="#"  id="editAddress"> edit this address</a>
-    </div>
+        <div class="form-group">
+            <input class="button" type="submit"  value="Find address">
+            or <a href="#"  id="editAddress"> edit this address</a>
+        </div>
 
     </form>
 

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -4,8 +4,7 @@
 
 GET        /hello-world                       controllers.HelloWorld.helloWorld
 GET        /address-lookup                    controllers.AddressLookup.addressLookup
-GET       /address-lookup-selection          controllers.AddressLookup.addressLookupSelection
-
+GET        /address-lookup-selection          controllers.AddressLookup.addressLookupSelection
 
 GET        /assets/*file                      controllers.Assets.at(path="/public", file)
 


### PR DESCRIPTION
Added confirmation page, allowing no fixed address and a selected list address to be displayed on the confirmation page. An edited address still needs to be displayed on the confirmation page. A selected list item now gets passed to the edit address page and pre fills the corresponding fields. Also split apart page redirects to individual button methods. Removed test file